### PR TITLE
Set default write queue length to 0 and display version on startup

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ListenerConfiguration.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ListenerConfiguration.java
@@ -153,7 +153,7 @@ public final class ListenerConfiguration {
         private int backlog = 1024;
         private Tls tls;
         private SocketOptions connectionOptions;
-        private int writeQueueLength = 32;
+        private int writeQueueLength = 0;
         private long maxPayloadSize = -1;
 
         private Builder(String socketName) {

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/LoomServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/LoomServer.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+import io.helidon.common.Version;
 import io.helidon.nima.webserver.http.DirectHandlers;
 import io.helidon.nima.webserver.spi.ServerConnectionProvider;
 
@@ -181,7 +182,8 @@ class LoomServer implements WebServer {
         now = System.currentTimeMillis() - now;
         long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
 
-        LOGGER.log(System.Logger.Level.INFO, "Níma server started all channels in "
+        LOGGER.log(System.Logger.Level.INFO, "Helidon Níma " + Version.VERSION);
+        LOGGER.log(System.Logger.Level.INFO, "Started all channels in "
                 + now + " milliseconds. "
                 + uptime + " milliseconds since JVM startup. "
                 + "Java " + Runtime.version());


### PR DESCRIPTION
Set default write queue length to 0. Display version on startup.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>