### PR TITLE
11430: Fix bulkhead queued invocation races

### DIFF
--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,8 @@ public interface Bulkhead extends FtHandler, RuntimeType.Api<BulkheadConfig> {
 
     /**
      * Can be used to cancel a supplier while queued.
+     * The same supplier instance passed to {@link #invoke(Supplier)} must be used.
+     * If the same instance is queued multiple times, each call cancels at most one queued invocation.
      *
      * @param supplier the supplier
      * @return outcome of cancellation

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
@@ -17,18 +17,16 @@
 package io.helidon.faulttolerance;
 
 import java.lang.System.Logger.Level;
-import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
@@ -51,7 +49,6 @@ class BulkheadImpl implements Bulkhead {
     private final AtomicLong callsRejected = new AtomicLong(0L);
     private final AtomicLong callsWaiting = new AtomicLong(0L);
     private final List<QueueListener> listeners;
-    private final Set<Supplier<?>> cancelledSuppliers = new CopyOnWriteArraySet<>();
     private final BulkheadConfig config;
     private final boolean metricsEnabled;
 
@@ -128,9 +125,9 @@ class BulkheadImpl implements Bulkhead {
             throw new BulkheadException("Bulkhead queue \"" + name + "\" is full");
         }
 
+        QueuedInvocation queuedInvocation = null;
         try {
             // block current thread until barrier is retracted
-            Barrier barrier;
             boolean waitingCounted = false;
             try {
                 listeners.forEach(l -> l.enqueueing(supplier));
@@ -138,12 +135,12 @@ class BulkheadImpl implements Bulkhead {
                     callsWaiting.incrementAndGet();
                     waitingCounted = true;
                 }
-                barrier = queue.enqueue(supplier);
+                queuedInvocation = queue.enqueue(supplier);
             } finally {
                 inProgressLock.unlock(); // we have enqueued, now we can wait
             }
 
-            if (barrier == null) {
+            if (queuedInvocation == null) {
                 if (waitingCounted) {
                     callsWaiting.decrementAndGet();
                 }
@@ -155,7 +152,7 @@ class BulkheadImpl implements Bulkhead {
                 waitStartedAt = System.nanoTime();
             }
             try {
-                barrier.waitOn();
+                queuedInvocation.waitOn();
             } finally {
                 if (waitingCounted) {
                     waitingDurationMetric.record(System.nanoTime() - waitStartedAt, TimeUnit.NANOSECONDS);
@@ -163,13 +160,13 @@ class BulkheadImpl implements Bulkhead {
                 }
             }
 
-            // unblocked so we can proceed with execution
-            listeners.forEach(l -> l.dequeued(supplier));
-
             // do not run if cancelled while queued
-            if (cancelledSuppliers.remove(supplier)) {
+            if (queuedInvocation.cancelled()) {
                 return null;
             }
+
+            // unblocked so we can proceed with execution
+            listeners.forEach(l -> l.dequeued(supplier));
 
             // invoke supplier now
             if (LOGGER.isLoggable(Level.DEBUG)) {
@@ -177,7 +174,15 @@ class BulkheadImpl implements Bulkhead {
             }
             return execute(supplier);
         } catch (InterruptedException e) {
+            if (queuedInvocation != null) {
+                if (queue.remove(queuedInvocation)) {
+                    queuedInvocation.interrupt();
+                } else if (queuedInvocation.started()) {
+                    handOffOrReleasePermit();
+                }
+            }
             callsRejected.incrementAndGet();
+            Thread.currentThread().interrupt();
             throw new BulkheadException("Bulkhead \"" + name + "\" interrupted while acquiring");
         } catch (ExecutionException e) {
             throw new BulkheadException(e.getMessage());
@@ -227,24 +232,27 @@ class BulkheadImpl implements Bulkhead {
             throw SupplierHelper.toRuntimeException(throwable);
         } finally {
             concurrentExecutions.decrementAndGet();
-            inProgressLock.lock();
-            try {
-                boolean dequeued = queue.dequeueAndRetract();
-                if (!dequeued) {
-                    inProgress.release();       // nothing dequeued, one more permit
-                }
-            } finally {
-                inProgressLock.unlock();
+            handOffOrReleasePermit();
+        }
+    }
+
+    private void handOffOrReleasePermit() {
+        inProgressLock.lock();
+        try {
+            boolean dequeued = queue.dequeueAndRetract();
+            if (!dequeued) {
+                inProgress.release();       // nothing dequeued, one more permit
             }
+        } finally {
+            inProgressLock.unlock();
         }
     }
 
     @Override
     public boolean cancelSupplier(Supplier<?> supplier) {
-        Barrier barrier = queue.remove(supplier);
-        if (barrier != null) {
-            cancelledSuppliers.add(supplier);
-            barrier.retract();
+        QueuedInvocation queuedInvocation = queue.remove(supplier);
+        if (queuedInvocation != null) {
+            queuedInvocation.cancel();
             return true;
         }
         return false;
@@ -273,24 +281,32 @@ class BulkheadImpl implements Bulkhead {
          * Enqueue supplier and block thread on barrier.
          *
          * @param supplier the supplier
-         * @return barrier if supplier was enqueued or null otherwise
+         * @return queued invocation if supplier was enqueued or null otherwise
          */
-        Barrier enqueue(Supplier<?> supplier);
+        QueuedInvocation enqueue(Supplier<?> supplier);
 
         /**
-         * Dequeue supplier and retract its barrier.
+         * Dequeue supplier and release its queued invocation.
          *
          * @return {@code true} if a supplier was dequeued or {@code false} otherwise
          */
         boolean dequeueAndRetract();
 
         /**
-         * Remove supplier from queue, if present, and return its barrier for external completion.
+         * Remove supplier from queue by identity, if present, and return its queued invocation for external completion.
          *
          * @param supplier the supplier
-         * @return barrier associated with the removed supplier, or {@code null} if the supplier was not removed
+         * @return queued invocation associated with the removed supplier, or {@code null} if the supplier was not removed
          */
-        Barrier remove(Supplier<?> supplier);
+        QueuedInvocation remove(Supplier<?> supplier);
+
+        /**
+         * Remove a specific queued invocation if it is still in the queue.
+         *
+         * @param queuedInvocation queued invocation to remove
+         * @return {@code true} if the invocation was removed or {@code false} otherwise
+         */
+        boolean remove(QueuedInvocation queuedInvocation);
     }
 
     /**
@@ -309,7 +325,7 @@ class BulkheadImpl implements Bulkhead {
         }
 
         @Override
-        public Barrier enqueue(Supplier<?> supplier) {
+        public QueuedInvocation enqueue(Supplier<?> supplier) {
             // never enqueue, should always fail execution if permits are not available
             return null;
         }
@@ -320,8 +336,13 @@ class BulkheadImpl implements Bulkhead {
         }
 
         @Override
-        public Barrier remove(Supplier<?> supplier) {
+        public QueuedInvocation remove(Supplier<?> supplier) {
             return null;
+        }
+
+        @Override
+        public boolean remove(QueuedInvocation queuedInvocation) {
+            return false;
         }
     }
 
@@ -334,8 +355,7 @@ class BulkheadImpl implements Bulkhead {
 
         private final int capacity;
         private final ReentrantLock lock;
-        private final Queue<Supplier<?>> queue;
-        private final Map<Supplier<?>, Barrier> map;
+        private final Queue<QueuedInvocation> queue;
 
         BlockingQueue(int capacity) {
             if (capacity <= 0) {
@@ -343,7 +363,6 @@ class BulkheadImpl implements Bulkhead {
             }
             this.capacity = capacity;
             this.queue = new LinkedBlockingQueue<>(capacity);
-            this.map = new IdentityHashMap<>();     // just use references
             this.lock = new ReentrantLock();
         }
 
@@ -363,7 +382,7 @@ class BulkheadImpl implements Bulkhead {
         }
 
         @Override
-        public Barrier enqueue(Supplier<?> supplier) {
+        public QueuedInvocation enqueue(Supplier<?> supplier) {
             lock.lock();
             try {
                 return doEnqueue(supplier);
@@ -376,9 +395,9 @@ class BulkheadImpl implements Bulkhead {
         public boolean dequeueAndRetract() {
             lock.lock();
             try {
-                Barrier barrier = dequeue();
-                if (barrier != null) {
-                    barrier.retract();
+                QueuedInvocation queuedInvocation = dequeue();
+                if (queuedInvocation != null) {
+                    queuedInvocation.start();
                     return true;
                 }
                 return false;
@@ -388,24 +407,97 @@ class BulkheadImpl implements Bulkhead {
         }
 
         @Override
-        public Barrier remove(Supplier<?> supplier) {
+        public QueuedInvocation remove(Supplier<?> supplier) {
             lock.lock();
             try {
-                boolean removed = queue.remove(supplier);
-                return removed ? map.remove(supplier) : null;
+                for (Iterator<QueuedInvocation> iterator = queue.iterator(); iterator.hasNext();) {
+                    QueuedInvocation queuedInvocation = iterator.next();
+                    if (queuedInvocation.supplier() == supplier) {
+                        iterator.remove();
+                        return queuedInvocation;
+                    }
+                }
+                return null;
             } finally {
                 lock.unlock();
             }
         }
 
-        private Barrier dequeue() {
-            Supplier<?> supplier = queue.poll();
-            return supplier == null ? null : map.remove(supplier);
+        @Override
+        public boolean remove(QueuedInvocation queuedInvocation) {
+            lock.lock();
+            try {
+                for (Iterator<QueuedInvocation> iterator = queue.iterator(); iterator.hasNext();) {
+                    if (iterator.next() == queuedInvocation) {
+                        iterator.remove();
+                        return true;
+                    }
+                }
+                return false;
+            } finally {
+                lock.unlock();
+            }
         }
 
-        private Barrier doEnqueue(Supplier<?> supplier) {
-            boolean added = queue.offer(supplier);
-            return added ? map.computeIfAbsent(supplier, s -> new Barrier()) : null;
+        private QueuedInvocation dequeue() {
+            return queue.poll();
+        }
+
+        private QueuedInvocation doEnqueue(Supplier<?> supplier) {
+            QueuedInvocation queuedInvocation = new QueuedInvocation(supplier);
+            boolean added = queue.offer(queuedInvocation);
+            return added ? queuedInvocation : null;
+        }
+    }
+
+    private static class QueuedInvocation {
+        private final AtomicReference<State> state = new AtomicReference<>(State.QUEUED);
+        private final Supplier<?> supplier;
+        private final Barrier barrier = new Barrier();
+
+        private QueuedInvocation(Supplier<?> supplier) {
+            this.supplier = supplier;
+        }
+
+        private Supplier<?> supplier() {
+            return supplier;
+        }
+
+        private void waitOn() throws ExecutionException, InterruptedException {
+            barrier.waitOn();
+        }
+
+        private boolean start() {
+            boolean started = state.compareAndSet(State.QUEUED, State.STARTED);
+            if (started) {
+                barrier.retract();
+            }
+            return started;
+        }
+
+        private boolean started() {
+            return state.get() == State.STARTED;
+        }
+
+        private boolean cancelled() {
+            return state.get() == State.CANCELLED;
+        }
+
+        private void cancel() {
+            if (state.compareAndSet(State.QUEUED, State.CANCELLED)) {
+                barrier.retract();
+            }
+        }
+
+        private void interrupt() {
+            state.compareAndSet(State.QUEUED, State.INTERRUPTED);
+        }
+
+        private enum State {
+            QUEUED,
+            STARTED,
+            CANCELLED,
+            INTERRUPTED
         }
     }
 

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/BulkheadTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/BulkheadTest.java
@@ -20,6 +20,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import io.helidon.logging.common.LogConfig;
@@ -170,6 +172,7 @@ class BulkheadTest extends BulkheadBaseTest {
     @Test
     void testCancelQueuedSupplier() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
         CountDownLatch queuedSubmitted = new CountDownLatch(1);
+        AtomicInteger dequeued = new AtomicInteger();
         Bulkhead bulkhead = Bulkhead.builder()
                 .limit(1)
                 .queueLength(1)
@@ -177,6 +180,11 @@ class BulkheadTest extends BulkheadBaseTest {
                     @Override
                     public <T> void enqueueing(Supplier<? extends T> supplier) {
                         queuedSubmitted.countDown();
+                    }
+
+                    @Override
+                    public <T> void dequeued(Supplier<? extends T> supplier) {
+                        dequeued.incrementAndGet();
                     }
                 })
                 .build();
@@ -200,10 +208,190 @@ class BulkheadTest extends BulkheadBaseTest {
         assertThat(bulkhead.cancelSupplier(queuedSupplier), is(true));
         assertThat(queuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(nullValue()));
         assertThat(queued.isStarted(), is(false));
+        assertThat(dequeued.get(), is(0));
         assertThat(bulkhead.stats().waitingQueueSize(), is(0L));
 
         inProgress.unblock();
         inProgressResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void testCancelQueuedSupplierRequiresSameInstance()
+            throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        CountDownLatch queuedSubmitted = new CountDownLatch(1);
+        Bulkhead bulkhead = Bulkhead.builder()
+                .limit(1)
+                .queueLength(1)
+                .addQueueListener(new Bulkhead.QueueListener() {
+                    @Override
+                    public <T> void enqueueing(Supplier<? extends T> supplier) {
+                        queuedSubmitted.countDown();
+                    }
+                })
+                .build();
+
+        Task inProgress = new Task(0);
+        CompletableFuture<Integer> inProgressResult = Async.invokeStatic(() -> bulkhead.invoke(inProgress::run));
+
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress not started");
+        }
+
+        Task queued = new Task(1);
+        Supplier<Integer> queuedSupplier = new EqualSupplier<>(1, queued::run);
+        Supplier<Integer> equalButDistinctSupplier = new EqualSupplier<>(1, () -> 99);
+        CompletableFuture<Integer> queuedResult = Async.invokeStatic(() -> bulkhead.invoke(queuedSupplier));
+
+        if (!queuedSubmitted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+            fail("Task queued never submitted");
+        }
+        assertEventually(() -> bulkhead.stats().waitingQueueSize() == 1, WAIT_TIMEOUT_MILLIS);
+
+        assertFalse(bulkhead.cancelSupplier(equalButDistinctSupplier));
+        assertThat(bulkhead.stats().waitingQueueSize(), is(1L));
+
+        inProgress.unblock();
+        inProgressResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        if (!queued.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task queued not started");
+        }
+        queued.unblock();
+        assertThat(queuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(1));
+    }
+
+    @Test
+    void testCancelQueuedSupplierWithSameInstanceQueuedTwice()
+            throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        CountDownLatch queuedSubmitted = new CountDownLatch(2);
+        CountDownLatch sharedStarted = new CountDownLatch(1);
+        CountDownLatch allowSharedToFinish = new CountDownLatch(1);
+        AtomicInteger sharedRuns = new AtomicInteger();
+        Bulkhead bulkhead = Bulkhead.builder()
+                .limit(1)
+                .queueLength(2)
+                .addQueueListener(new Bulkhead.QueueListener() {
+                    @Override
+                    public <T> void enqueueing(Supplier<? extends T> supplier) {
+                        queuedSubmitted.countDown();
+                    }
+                })
+                .build();
+
+        Task inProgress = new Task(0);
+        CompletableFuture<Integer> inProgressResult = Async.invokeStatic(() -> bulkhead.invoke(inProgress::run));
+
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress not started");
+        }
+
+        Supplier<Integer> sharedSupplier = () -> {
+            sharedRuns.incrementAndGet();
+            sharedStarted.countDown();
+            try {
+                allowSharedToFinish.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return 1;
+        };
+
+        CompletableFuture<Integer> firstQueuedResult = Async.invokeStatic(() -> bulkhead.invoke(sharedSupplier));
+        CompletableFuture<Integer> secondQueuedResult = Async.invokeStatic(() -> bulkhead.invoke(sharedSupplier));
+
+        if (!queuedSubmitted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+            fail("Queued tasks were not submitted");
+        }
+        assertEventually(() -> bulkhead.stats().waitingQueueSize() == 2, WAIT_TIMEOUT_MILLIS);
+
+        assertTrue(bulkhead.cancelSupplier(sharedSupplier));
+        assertEventually(() -> bulkhead.stats().waitingQueueSize() == 1, WAIT_TIMEOUT_MILLIS);
+        assertFalse(sharedStarted.await(200, TimeUnit.MILLISECONDS));
+
+        inProgress.unblock();
+        inProgressResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        if (!sharedStarted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+            fail("Shared supplier not started");
+        }
+        allowSharedToFinish.countDown();
+
+        Integer firstResult = firstQueuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Integer secondResult = secondQueuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        assertThat(sharedRuns.get(), is(1));
+        assertThat((firstResult == null) ^ (secondResult == null), is(true));
+        assertThat(firstResult == null ? secondResult : firstResult, is(1));
+        assertThat(bulkhead.stats().waitingQueueSize(), is(0L));
+    }
+
+    @RepeatedTest(100)
+    void testInterruptedQueuedSupplierDoesNotLeakPermit()
+            throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        String name = "unit:testInterruptedQueuedSupplierDoesNotLeakPermit";
+        CountDownLatch queuedSubmitted = new CountDownLatch(2);
+        AtomicReference<Thread> interruptedQueuedThread = new AtomicReference<>();
+        Bulkhead bulkhead = Bulkhead.builder()
+                .limit(1)
+                .queueLength(2)
+                .name(name)
+                .addQueueListener(new Bulkhead.QueueListener() {
+                    @Override
+                    public <T> void enqueueing(Supplier<? extends T> supplier) {
+                        queuedSubmitted.countDown();
+                    }
+                })
+                .build();
+
+        Task inProgress = new Task(0);
+        CompletableFuture<Integer> inProgressResult = Async.invokeStatic(() -> bulkhead.invoke(inProgress::run));
+
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress not started");
+        }
+
+        Task interruptedQueued = new Task(1);
+        Supplier<Integer> interruptedSupplier = interruptedQueued::run;
+        CompletableFuture<Integer> interruptedQueuedResult = new CompletableFuture<>();
+        Thread.ofVirtual().start(() -> {
+            interruptedQueuedThread.set(Thread.currentThread());
+            try {
+                interruptedQueuedResult.complete(bulkhead.invoke(interruptedSupplier));
+            } catch (Throwable t) {
+                interruptedQueuedResult.completeExceptionally(t);
+            }
+        });
+
+        Task nextQueued = new Task(2);
+        CompletableFuture<Integer> nextQueuedResult = Async.invokeStatic(() -> bulkhead.invoke(nextQueued::run));
+
+        if (!queuedSubmitted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+            fail("Queued tasks were not submitted");
+        }
+        assertEventually(() -> bulkhead.stats().waitingQueueSize() == 2
+                && waitingOnBarrier(interruptedQueuedThread.get()), WAIT_TIMEOUT_MILLIS);
+
+        interruptedQueuedThread.get().interrupt();
+
+        ExecutionException executionException = assertThrows(ExecutionException.class,
+                () -> interruptedQueuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        Throwable cause = executionException.getCause();
+        assertThat(cause, notNullValue());
+        assertThat(cause, instanceOf(BulkheadException.class));
+        assertThat(cause.getMessage(), is("Bulkhead \"" + name + "\" interrupted while acquiring"));
+        assertThat(interruptedQueued.isStarted(), is(false));
+        assertEventually(() -> bulkhead.stats().waitingQueueSize() == 1, WAIT_TIMEOUT_MILLIS);
+
+        inProgress.unblock();
+        inProgressResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        if (!nextQueued.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task nextQueued not started");
+        }
+        nextQueued.unblock();
+        assertThat(nextQueuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(2));
+        assertThat(bulkhead.stats().waitingQueueSize(), is(0L));
     }
 
     @RepeatedTest(100)
@@ -241,5 +429,49 @@ class BulkheadTest extends BulkheadBaseTest {
         Throwable cause = executionException.getCause();
         assertThat(cause, notNullValue());
         assertThat(cause, instanceOf(IllegalStateException.class));
+    }
+
+    private static final class EqualSupplier<T> implements Supplier<T> {
+        private final int id;
+        private final Supplier<T> delegate;
+
+        private EqualSupplier(int id, Supplier<T> delegate) {
+            this.id = id;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public T get() {
+            return delegate.get();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof EqualSupplier<?> that)) {
+                return false;
+            }
+            return id == that.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(id);
+        }
+    }
+
+    private static boolean waitingOnBarrier(Thread thread) {
+        if (thread == null) {
+            return false;
+        }
+        for (StackTraceElement element : thread.getStackTrace()) {
+            if (element.getClassName().equals(BulkheadImpl.class.getName() + "$Barrier")
+                    && element.getMethodName().equals("waitOn")) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Description

Follow-up to helidon-io/helidon#11432 for helidon-io/helidon#11430.

This change:
- keeps dequeue accounting tied to actual queue removal instead of cancelled waiters
- tracks queued invocation state per enqueue so reused suppliers do not share cancellation state
- avoids permit leaks or transfers when a queued waiter is interrupted
- adds regression coverage for cancellation, supplier reuse, and interruption races

### Documentation

None
