### PR TITLE
Preserve bulkhead waiting timing after dequeue race

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -378,10 +378,11 @@ class MethodInvoker implements FtSupplier<Object> {
                 cancellableSupplier.cancel();
                 // Cancel supplier in bulkhead in case it is queued
                 if (introspector.hasBulkhead()) {
-                    if (methodState.bulkheadWaitingStarts != null) {
+                    boolean removedFromQueue = methodState.bulkhead.cancelSupplier(handlerSupplier);
+                    // If the supplier was already dequeued, the queue listener owns recording waiting time.
+                    if (removedFromQueue && methodState.bulkheadWaitingStarts != null) {
                         methodState.bulkheadWaitingStarts.remove(handlerSupplier);
                     }
-                    methodState.bulkhead.cancelSupplier(handlerSupplier);
                 }
                 asyncFuture.cancel(mayInterrupt.get());
             }


### PR DESCRIPTION
Follow-up to helidon-io/helidon#12010.

This keeps async bulkhead waiting-duration cleanup conditional on successfully removing the supplier from the queue. If cancellation races with dequeue and the supplier is already handed off, the queue listener should still own recording the precise waiting duration.

Validation:

- mvn -q -pl microprofile/fault-tolerance -Dtest=MetricsTest,BulkheadTest test
- mvn -q -pl fault-tolerance/fault-tolerance -Dtest=BulkheadTest,BulkheadMetricsTest test